### PR TITLE
Fix Install.bat path

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
-COPY ".\Ext-Icons" "%LocalAppData%\Programs\ImageGlass\Ext-Icons"
+COPY ".\Ext-Icons" "%LocalAppData%\ImageGlass\Ext-Icons"
 ECHO Done, press any key to exit . . .
 PAUSE>NUL


### PR DESCRIPTION
https://imageglass.org/docs/app-configs
> Configuration directory (Config Dir): This directory houses the ImageGlass settings file (igconfig.json) and other related files. It's typically located in %LocalAppData%\ImageGlass\. In portable mode, the Config Dir is the same as the Startup Dir. If ImageGlass lacks write permissions in the Startup Dir, it will use %LocalAppData%\ImageGlass\ instead.

### Description

### Checklist:
- [x] The code has been tested.
